### PR TITLE
Added LOCAL_LDFLAGS so the build will find the locally linked crypto and...

### DIFF
--- a/libnode/jni/Android.mk
+++ b/libnode/jni/Android.mk
@@ -40,6 +40,9 @@ LOCAL_LDLIBS += \
 	-lssl \
 	-lcrypto
 
+LOCAL_LDFLAGS += \
+   -L $(NODE_PATH)/../openssl-android/libs/armeabi
+
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,deps/uv)


### PR DESCRIPTION
... ssl libs. This way there is no need to create symbolic links in the NDK to these files.
