### PR TITLE
Allow a dynamic NODE_PATH

### DIFF
--- a/libnode/jni/src/defines.h
+++ b/libnode/jni/src/defines.h
@@ -1,7 +1,6 @@
 #ifndef DEFINES_H
 #define DEFINES_H
 
-#define MODULE_PATH "/data/data/org.meshpoint.anode/node_modules"
 #define DEFAULT_MODE (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 
 #endif

--- a/libnode/jni/src/org_meshpoint_anode_RuntimeNative.cpp
+++ b/libnode/jni/src/org_meshpoint_anode_RuntimeNative.cpp
@@ -55,19 +55,22 @@ static int getNativeArgs(JNIEnv *jniEnv, jobjectArray jargv, char ***pargv) {
 /*
  * Class:     org_meshpoint_anode_RuntimeNative
  * Method:    nodeInit
- * Signature: ([Ljava/lang/String;)V
+ * Signature: ([Ljava/lang/String;Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_org_meshpoint_anode_RuntimeNative_nodeInit
-  (JNIEnv *jniEnv, jclass, jobjectArray jargv) {
+	(JNIEnv *jniEnv, jclass, jobjectArray jargv, jstring jModulePath) {
 	LOGV("Java_org_meshpoint_anode_RuntimeNative_nodeInit: ent\n");
-	
-  /* set environment variable to support modules */
-  setenv("NODE_PATH", MODULE_PATH, 0);
-  
-  /* process node arguments */
-  char **argv;
-  int argc;
-  if((argc = getNativeArgs(jniEnv, jargv, &argv)) >= 0)
+
+	/* set environment variable to support node modules */
+	const char *modulePath = jniEnv->GetStringUTFChars(jModulePath, 0);
+	setenv("NODE_PATH", modulePath, 0);
+	jniEnv->ReleaseStringUTFChars(jModulePath, modulePath);
+	modulePath = NULL;
+
+	/* process node arguments */
+	char **argv;
+	int argc;
+	if((argc = getNativeArgs(jniEnv, jargv, &argv)) >= 0)
 	  node::Initialize(argc, argv);
 	LOGV("Java_org_meshpoint_anode_RuntimeNative_nodeInit: ret\n");
 }

--- a/libnode/jni/src/org_meshpoint_anode_RuntimeNative.h
+++ b/libnode/jni/src/org_meshpoint_anode_RuntimeNative.h
@@ -21,7 +21,7 @@ extern "C" {
  * Signature: ([Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_org_meshpoint_anode_RuntimeNative_nodeInit
-  (JNIEnv *, jclass, jobjectArray);
+  (JNIEnv *, jclass, jobjectArray, jstring jModulePath);
 
 /*
  * Class:     org_meshpoint_anode_RuntimeNative

--- a/libnode/src/org/meshpoint/anode/RuntimeNative.java
+++ b/libnode/src/org/meshpoint/anode/RuntimeNative.java
@@ -35,13 +35,20 @@ final class RuntimeNative {
 	 * @throws UnsatisifiedLinkError if there was a problem initialising the native library
 	 */
 	static void init(Context ctx, String[] argv) throws IOException {
+		char sep = File.separatorChar;
+		String packageName = ctx.getPackageName();
+		
+		// Example: `/data/data/org.mypackage.android/node_modules`
+		// TODO: make the node dynamic library not depend on assumed /data/data filesystem structure
+		String modulePath = sep + "data" + sep + "data" + sep + packageName + sep + "node_modules";
+		
 		try {
 			extractLib(ctx, RUNTIME_PATH, RUNTIME_LIBRARY);
 			System.load(RUNTIME_PATH + '/' + RUNTIME_LIBRARY);
 			extractLib(ctx, MODULE_PATH, BRIDGE_LIBRARY);
 			System.load(MODULE_PATH + '/' + BRIDGE_LIBRARY);
 			Log.v(TAG, "init: loaded libraries");
-			nodeInit(argv);
+			nodeInit(argv, modulePath);
 		} catch(UnsatisfiedLinkError e) {
 			Log.v(TAG, "init: unable to load library: " + e);
 			throw e;
@@ -54,7 +61,7 @@ final class RuntimeNative {
 	/**
 	 * Initialise the native node runtime
 	 */
-	static native void nodeInit(String[] argv);
+	static native void nodeInit(String[] argv, String modulePath);
 	
 	/**
 	 * Dispose the native node runtime


### PR DESCRIPTION
Enable third party developers to use their own package namespace when
using anode.  This is essential if you want anyone to publish applications
under a namespace other than org.meshpoint.anode
