### PR TITLE
TarExtractor and directories

### DIFF
--- a/app/src/org/meshpoint/anode/util/TarExtractor.java
+++ b/app/src/org/meshpoint/anode/util/TarExtractor.java
@@ -24,8 +24,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 
-import org.xeustechnologies.jtar.TarEntry;
-import org.xeustechnologies.jtar.TarInputStream;
+import org.kamranzafar.jtar.TarEntry;
+import org.kamranzafar.jtar.TarInputStream;
 
 public class TarExtractor implements ModuleUtils.Unpacker {
 
@@ -35,34 +35,76 @@ public class TarExtractor implements ModuleUtils.Unpacker {
 		byte[] buf = new byte[1024];
 		GZIPInputStream zis = null;
 		zis = new GZIPInputStream(new FileInputStream(src));
-		FileOutputStream tarfos = new FileOutputStream(tarFile);             
+		FileOutputStream tarfos = new FileOutputStream(tarFile);
 		int count;
 		while ((count = zis.read(buf, 0, 1024)) != -1)
 			tarfos.write(buf, 0, count);
-		tarfos.close(); 
+		tarfos.close();
 		zis.close();
 
 		/* now unpack the tar */
-		TarInputStream tis = new TarInputStream(new BufferedInputStream(new FileInputStream(tarFile)));
+		TarInputStream tis = new TarInputStream(new BufferedInputStream(
+			new FileInputStream(tarFile)));
 		TarEntry entry;
-		while((entry = tis.getNextEntry()) != null) {
+		while ((entry = tis.getNextEntry()) != null) {
 			File entryFile = new File(dest, entry.getName());
 			File parentDir = new File(entryFile.getParent());
-			if(!parentDir.isDirectory() && !parentDir.mkdirs())
-				throw new IOException("TarExtractor.unpack(): unable to create directory");
 
-			FileOutputStream fos = new FileOutputStream(entryFile);
-			BufferedOutputStream bos = new BufferedOutputStream(fos);
-			while((count = tis.read(buf)) != -1)
-				bos.write(buf, 0, count);
+			if (!parentDir.isDirectory() && !parentDir.mkdirs()) {
+				tis.close();
+				throw new IOException(
+					"TarExtractor.unpack(): unable to create directory");
+			}
 
-			bos.flush();
-			bos.close();
+			if (entry.getName().equals("././@LongLink")) {
+				// GNU tar format not supported by jtar
+				// attempt to recover:
+				// LongLink entry provides full file name for following entry
+				// -> read file name from body and skip ahead
+				String filename = "";
+				while ((count = tis.read(buf)) != -1) {
+					filename += new String(buf, 0, count - 1);
+				}
+				entry = tis.getNextEntry();
+				entryFile = new File(dest, filename);
+				android.util.Log.v("TarExtractor",
+					String.format("Encountered long filename." +
+						" Moving on to: %s:%s -> %s",
+						entry.getName(), entry.isDirectory(), entryFile));
+			}
+			if (entry.isDirectory()) {
+				if (entryFile.isDirectory()) {
+					// directory already exists
+					android.util.Log.v("TarExtractor",
+						"directory for " + entry.getName() + " already exists");
+				} else if (entryFile.mkdir()) {
+					// directory created (side effect)
+					android.util.Log.v("TarExtractor",
+						"directory created for " + entry.getName());
+				} else {
+					// fail
+					android.util.Log.w("TarExtractor",
+						"failed to create directory for " + entry.getName());
+				}
+			} else if (!entryFile.isDirectory()) {
+				FileOutputStream fos = new FileOutputStream(entryFile);
+				BufferedOutputStream bos = new BufferedOutputStream(fos);
+				while ((count = tis.read(buf)) != -1) {
+					bos.write(buf, 0, count);
+				}
+
+				bos.flush();
+				bos.close();
+			} else {
+				android.util.Log.v("TarExtractor",
+					String.format("What? %s:%s:%s", entryFile,
+						entryFile.isDirectory(), entry.isDirectory())
+					);
+			}
 		}
-		tis.close();		
+		tis.close();
 
 		/* delete the tar file */
 		tarFile.delete();
 	}
-
 }


### PR DESCRIPTION
this fix should handle directories better.
i attempted a workaround for GNU tar files with long filenames, but it does not always work.
this requires jtar-2.2 or later because the package name changed and older versions dont support ustar format, needed for long filenames.

cheers
