### PR TITLE
AnodeActivity: An instance launched through activity is never removed from AnodeService

### DIFF
--- a/app/src/org/meshpoint/anode/AnodeActivity.java
+++ b/app/src/org/meshpoint/anode/AnodeActivity.java
@@ -151,6 +151,9 @@ public class AnodeActivity extends Activity implements StateListener {
 		stopButton.setEnabled(state == Runtime.STATE_STARTED);
 		/* exit the activity if the runtime has exited */
 		if(state == Runtime.STATE_STOPPED) {
+			AnodeService.removeInstance(instance);
+			isolate.removeStateListener(this);
+			isolate = null;
 			finish();
 		}
 	}


### PR DESCRIPTION
Since AnodeActivity calls addInstance directly, when starting an isolate,
it should also remove them, when they stop.
The additional cleanup may be considered overkill, but i doubt it hurts.

cheers
